### PR TITLE
HFP-4258 Fix runnable configuration

### DIFF
--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
   "majorVersion": 1,
   "minorVersion": 0,
   "patchVersion": 5,
-  "runnable": 1,
+  "runnable": 0,
   "author": "H5P Group",
   "license": "MIT",
   "machineName": "H5P.Components",


### PR DESCRIPTION
When merged in, will change the runnable property to 0, as 1 is reserved for content types