### PR TITLE
feature/AU-7268 Add overrides for positioning of front-page

### DIFF
--- a/src/styles/h5p-cover-page.css
+++ b/src/styles/h5p-cover-page.css
@@ -72,4 +72,18 @@
 .h5p-theme-cover-description {
   color: var(--h5p-theme-text-secondary);
   margin: 0 0 var(--h5p-theme-spacing-l);
+
+  > p {
+    text-align: left !important;
+
+    @media (max-width: 576px) {
+      text-align: center !important;
+    }
+  }
+}
+
+@media (max-width: 576px) {
+  .h5p-theme-book {
+    margin: auto;
+  }
 }


### PR DESCRIPTION
NB! This overrides the author's ability to align the description text which is a concious decision for the theming changes.
This was done because changing h5p-editor to remove the alignment option would not allow the content to be backwards-compatible with the non-themed version of the content.
