### PR TITLE
VA-739 Remove 1rem base front size

### DIFF
--- a/src/styles/h5p-result-screen.css
+++ b/src/styles/h5p-result-screen.css
@@ -1,7 +1,3 @@
-.h5p-theme-result-screen {
-  font-size: 1rem; /* Ensure base font size for endscreen is 1rem */
-}
-
 /* Main banner */
 .h5p-theme-results-banner {
   position: relative;


### PR DESCRIPTION
When merged in, will remove 1rem base front size as requested by UX. Summary screen is supposed to resize, it seems.