### PR TITLE
VA-990 Use translate3d instead of translate

### DIFF
--- a/src/styles/h5p-button.css
+++ b/src/styles/h5p-button.css
@@ -69,7 +69,7 @@
 .h5p-theme-primary-cta:before {
   position: absolute;
   opacity: 0;
-  transform: translate(calc(-1 * var(--h5p-theme-spacing-xxs) - var(--h5p-theme-spacing-m) / 2), 10px);
+  transform: translate3d(calc(-1 * var(--h5p-theme-spacing-xxs) - var(--h5p-theme-spacing-m) / 2), 10px, 0);
   transition: all 0.1s linear 0s;
   transition-property: text-indent, transform, opacity;
   margin-right: 0;
@@ -77,7 +77,7 @@
 
 .h5p-theme-primary-cta:hover:before {
   opacity: 1;
-  transform: translate(0, 0);
+  transform: translate3d(0, 0, 0);
   text-indent: calc(-1 * var(--h5p-theme-spacing-xxs));
 }
 


### PR DESCRIPTION
When merged in, will use `translate3d` instead of `translate` as a workaround for Safari layout shifts.