### PR TITLE
Fix primary icon cta wobbling on Safari

### DIFF
--- a/src/styles/h5p-button.css
+++ b/src/styles/h5p-button.css
@@ -80,6 +80,13 @@
   transform: translate(calc(-1 * var(--h5p-theme-spacing-xxs) - var(--h5p-theme-spacing-m)), 0);
 }
 
+/* Will target Safari only which needs this or makes the whole content shift a bit. Applied selectively to prevent performance issues */
+@supports (-webkit-hyphens: none) and (not (-moz-appearance: none)) {
+  .h5p-theme-primary-cta:before {
+    will-change: transform;
+  }
+}
+
 /* If the container is smaller than 200px */
 @container (max-width: 200px) {
   .h5p-theme .h5p-theme-primary-cta {

--- a/src/styles/h5p-button.css
+++ b/src/styles/h5p-button.css
@@ -77,7 +77,6 @@
 
 .h5p-theme-primary-cta:hover:before {
   opacity: 1;
-  transform: translate(0, 0);
   transform: translate(calc(-1 * var(--h5p-theme-spacing-xxs) - var(--h5p-theme-spacing-m)), 0);
 }
 


### PR DESCRIPTION
When merged in, should stop Safari from shifting the whole content on primary cta button hover.