### PR TITLE
VA-1201 Remove margin from draggable component

### DIFF
--- a/src/styles/h5p-draggable.css
+++ b/src/styles/h5p-draggable.css
@@ -12,7 +12,6 @@
   display: flex;
   font-weight: bold;
   line-height: var(--h5p-theme-spacing-s);
-  margin: var(--h5p-theme-spacing-xxs);
   opacity: var(--opacity);
   padding: 0;
   text-align: center;


### PR DESCRIPTION
When merged in, will not set a margin on the draggable component any longer. Content types that require a margin need to set it themselves.