### PR TITLE
fix: Ensure HTML entities are printed correctly in cover page title

### DIFF
--- a/src/components/h5p-cover-page.js
+++ b/src/components/h5p-cover-page.js
@@ -1,5 +1,5 @@
 import '../styles/h5p-cover-page.css';
-import { createElement } from '../utils.js';
+import { createElement, parseString } from '../utils.js';
 import Button from './h5p-button.js';
 
 /**
@@ -73,7 +73,7 @@ function CoverPage(params) {
   }
 
   detailContainer.appendChild(createElement('h2', {
-    textContent: params.title,
+    textContent: parseString(params.title),
   }));
 
   if (params.description) {


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
See https://h5p.org/node/1565659
The CoverPage component is used by Interactve Book (and maybe others) and receives a title string with HTML entities: Apostrophes will be rendered as `&#039;`, etc.

**What is the new behaviour?**
Fixed by using the `parseString` function of the Component utilities intended for that purpose.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
